### PR TITLE
Fix compile errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,13 @@ async fn main() {
     let checker = checker::BlocklistCheckerStore::new(persister);
     let checker = Arc::new(checker);
     downloader::start(checker.clone());
-    let checker2 = checker.clone();
 
     let ips = warp::path!("ips" / String)
         .map(move |ip : String| {
             match Ipv4Addr::from_str(&ip)
             {
                 Ok(address) => {
-                    let checker = checker2;
+                    let checker = checker.clone();
                     String::from(if checker.contains(&address) { "true"} else { "false" })
                 },
                 Err(error) => format!("{} is not correct IP address, {}!", &ip, error)


### PR DESCRIPTION
You can never get mutable references to an object behind an Arc, because Arc is meant to be shared across threads and mut references should be exclusive. However this doesn't mean that you cannot get interior mutability of the object behind the Arc, the way to do it is to have the methods that mutate your object state to take a &self instead of a &mut self, once you have this self you need to obtain a mutable reference to the field you're planning to modify. How do you do this if you have an inmutable ref to self? well at some point (if your struct is really thread safe) the data you want to modify will be behind some kind of Mutex which indeed provides mutable access to their inner object even if you only have an inmutable reference.
