### PR TITLE
Fix unsafe code

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,4 +1,4 @@
-use std::sync::RwLock;
+use std::cell::UnsafeCell;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::net::Ipv4Addr;
@@ -9,11 +9,11 @@ pub trait BlocklistChecker {
 }
 
 pub trait BlocklistStore {
-    fn set_addresses<I>(&self, addresses : I) where I : Iterator<Item=Ipv4Addr>;
+    fn set_addresses<I>(&mut self, addresses : I) where I : Iterator<Item=Ipv4Addr>;
 }
 
 pub struct BlocklistCheckerStore {
-    addresses : RwLock<HashSet<Ipv4Addr>>,
+    addresses: UnsafeCell<HashSet<Ipv4Addr>>,
     persister: BlocklistPersister,
 }
 
@@ -24,14 +24,14 @@ impl BlocklistCheckerStore {
             Ok(iterator) => {
                 log::info!("Loaded addresses from DB");
                 Self {
-                    addresses: RwLock::new(HashSet::from_iter(iterator)),
+                    addresses: UnsafeCell::new(HashSet::from_iter(iterator)),
                     persister,
                 }
             }
             Err(error) => {
                 log::warn!("Failed to load DB on startup: {}.", error);
                 Self {
-                    addresses: RwLock::new(HashSet::new()),
+                    addresses: UnsafeCell::new(HashSet::new()),
                     persister,
                 }
             }
@@ -40,23 +40,23 @@ impl BlocklistCheckerStore {
 }
 
 impl BlocklistChecker for BlocklistCheckerStore {
-    fn contains(&self, ip: &Ipv4Addr) -> bool {
-        self.addresses.read().unwrap().contains(&ip)
-    }
+    fn contains(&self, ip: &Ipv4Addr) -> bool { unsafe { (*self.addresses.get()).contains(&ip) } }
 }
 
 impl BlocklistStore for BlocklistCheckerStore {
-    fn set_addresses<I>(&self, addresses: I) where I: Iterator<Item=Ipv4Addr> {
+    fn set_addresses<I>(&mut self, addresses: I) where I: Iterator<Item=Ipv4Addr> {
         // this is not thread safe if addresses is not behind a mutex
-        // self.addresses = HashSet::from_iter(addresses); 
+        // self.addresses = HashSet::from_iter(addresses);
 
-        let mut val  = self.addresses.write().unwrap();
-        *val = HashSet::from_iter(addresses);
+        self.addresses = UnsafeCell::new(HashSet::from_iter(addresses));
 
-        log::info!("Successfully refreshed blocklist with {} ips.", val.len());
-        match self.persister.persist(val.iter().map(|i| *i)) {
-            Ok(_) => log::info!("Saved blocklist to DB"),
-            Err(error) => log::error!("Failed to save DB: {}.", error)
+        unsafe {
+            let addresses = &*self.addresses.get();
+            log::info!("Successfully refreshed blocklist with {} ips.", addresses.len());
+            match self.persister.persist(addresses.iter().map(|i| *i)) {
+                Ok(_) => log::info!("Saved blocklist to DB"),
+                Err(error) => log::error!("Failed to save DB: {}.", error)
+            }
         }
     }
 }


### PR DESCRIPTION
Change `&mut self` to `&self` and fix unsafe blocks

You will never be able to get `&mut` from an object behind an `Arc`, the trick is to be able to mutate a field in `self` even when all you got is `&self`, in order to do that you need to use something that provides interior mutability, in this case, since we want to share it between threads and don't want to lock, we need to use `UnsafeCell` which gives us access to a raw pointer to our object in `unsafe` context.
